### PR TITLE
add `transformers` to pip install command

### DIFF
--- a/Integration_Canopy.ipynb
+++ b/Integration_Canopy.ipynb
@@ -28,7 +28,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install -qU canopy-sdk"
+    "!pip install -qU canopy-sdk transformers"
    ]
   },
   {


### PR DESCRIPTION
transformers is required by the LlamaTokenizer